### PR TITLE
add cso_ackley and pso_rastrigin, modified pso_ackley in example, and some simple modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# Exmaple
+# EvoX: A JAX-based EC Library
+
+### Brief Intro
+During the past decades, evolutionary computation (EC) has demonstrated promising potential in
+solving various complex optimization problems of relatively small scales. However, as modern 
+EC research is facing problems of a much larger scale, computing power begins to struggle. To
+meet this grave challenge, to present `EvoX`, a distributed GPU-accelerated EC library.
+In this report, we will show how `EvoX` is suitable for all EC algorithms while extending
+to many real-life benchmark problems. We will also show that `EvoX` can also greatly 
+accelerate EC workflow.
+
+### Simple Example
 
 ```python
 from evox import algorithms, problems, pipelines
@@ -28,5 +39,4 @@ for i in range(100):
 
 pipeline.fitness_monitor.show()
 pipeline.population_monitor.show()
-
 ```

--- a/examples/cso_ackley.py
+++ b/examples/cso_ackley.py
@@ -13,12 +13,12 @@ pop_monitor = PopulationMonitor(2)
 
 # create a pipeline
 pipeline = pipelines.StdPipeline(
-    algorithms.PSO(
+    algorithm=algorithms.CSO(
         lb=jnp.full(shape=(2,), fill_value=-32),
         ub=jnp.full(shape=(2,), fill_value=32),
         pop_size=POP_SIZE,
     ),
-    problems.classic.Ackley(),
+    problem=problems.classic.Ackley(),
     fitness_transform=fit_monitor.update,
     pop_transform=pop_monitor.update,
 )
@@ -36,5 +36,5 @@ for i in range(EPOCH_NUM):
     state = pipeline.step(state)
     print(fit_monitor.get_min_fitness())
 
-pop_monitor.save('PSO_Ackley_pop_information.html')
-fit_monitor.save('PSO_Ackley_fit_information.html')
+pop_monitor.save('CSO_Ackley_pop_information.html')
+fit_monitor.save('CSO_Ackley_fit_information.html')

--- a/examples/pso_rastrigin.py
+++ b/examples/pso_rastrigin.py
@@ -18,7 +18,7 @@ pipeline = pipelines.StdPipeline(
         ub=jnp.full(shape=(2,), fill_value=32),
         pop_size=POP_SIZE,
     ),
-    problems.classic.Ackley(),
+    problems.classic.Rastrigin(),
     fitness_transform=fit_monitor.update,
     pop_transform=pop_monitor.update,
 )
@@ -36,5 +36,5 @@ for i in range(EPOCH_NUM):
     state = pipeline.step(state)
     print(fit_monitor.get_min_fitness())
 
-pop_monitor.save('PSO_Ackley_pop_information.html')
-fit_monitor.save('PSO_Ackley_fit_information.html')
+pop_monitor.save('PSO_Rast_pop_information.html')
+fit_monitor.save('PSO_Rast_fit_information.html')

--- a/src/evox/monitors/fitness.py
+++ b/src/evox/monitors/fitness.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 import bokeh
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, show, save
 from bokeh.models import Spinner
 from evox.core.module import Stateful
 
@@ -22,7 +22,7 @@ class FitnessMonitor:
         self.history.append(self.min_fitness)
         return fitness
 
-    def show(self):
+    def _plot_figure(self):
         plot = figure(
             title="Fitness - Iteration",
             x_axis_label="Iteration",
@@ -46,7 +46,18 @@ class FitnessMonitor:
                 [plot],
             ]
         )
+        return layout
+
+    def show(self):
+        layout = self._plot_figure()
         show(layout)
+
+    def save(self, filename=None):
+        layout = self._plot_figure()
+        if filename is None:
+            save(layout)
+        else:
+            save(layout, filename=filename)
 
     def get_min_fitness(self):
         return self.min_fitness

--- a/src/evox/monitors/population.py
+++ b/src/evox/monitors/population.py
@@ -3,7 +3,7 @@ import chex
 import jax.numpy as jnp
 import numpy as np
 from bokeh.models import ColumnDataSource, Slider, Spinner, CustomJS
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, show, save
 from evox.core.module import Stateful
 
 
@@ -31,7 +31,7 @@ class PopulationMonitor:
         self.history.append(np.array(pop).T)
         return pop
 
-    def show(self):
+    def _plot_figure(self):
         # format self.history into ColumnDataSource acceptable format
         # use ColumnDataSource is more efficient than passing numpy array directly
         column_history = {}
@@ -67,11 +67,11 @@ class PopulationMonitor:
             CustomJS(
                 args={"source": source, "history": column_history},
                 code="""
-                    const iter = cb_obj.value
-                    source.data.x = history.data[`${iter}_x`]
-                    source.data.y = history.data[`${iter}_y`]
-                    source.change.emit();
-                """,
+                            const iter = cb_obj.value
+                            source.data.x = history.data[`${iter}_x`]
+                            source.data.y = history.data[`${iter}_y`]
+                            source.change.emit();
+                        """,
             ),
         )
 
@@ -91,4 +91,16 @@ class PopulationMonitor:
                 [plot],
             ]
         )
+
+        return layout
+
+    def show(self):
+        layout = self._plot_figure()
         show(layout)
+
+    def save(self, filename=None):
+        layout = self._plot_figure()
+        if filename is None:
+            save(layout)
+        else:
+            save(layout, filename=filename)


### PR DESCRIPTION
Simply modified readme.md

Include CSO_ Ackley and PSO_ Rastrigin, replace the original pso_ Ackley added. Previously, there was no fitness and population for the example of the classic function. Now all three examples have the visualization of fitness and population. Population can better understand the operation process of the whole algorithm according to the population monitor.

When the remote server ssh is connected, the current monitor cannot save the results, and the visualization cannot be viewed remotely. So we modified the monitor of population and fitness and added the save() function to support saving the visualization results in html format for viewing and retention.