### PR TITLE
dev: add init_ask and init_tell support

### DIFF
--- a/docs/source/guide/advanced/3-custom-alg-pro.md
+++ b/docs/source/guide/advanced/3-custom-alg-pro.md
@@ -20,6 +20,8 @@ In total, there are four methods one need to implement.
 | setup        | {python}`(self, RRNGKey) -> State`      | Initialize mutable state, for example the `momentum`.                                                              |
 | ask          | {python}`(self, State) -> Array, State` | Gives a candidate population for evaluation.                                                                       |
 | tell         | {python}`(self, State, Array) -> State` | Receive the fitness for the candidate population and update the algorithm's state.                                 |
+| init_ask (Optional)  | {python}`(self, State) -> Array, State` | Gives initial population for evaluation. The population can have different shape than `ask`.               |
+| init_tell (Optional) | {python}`(self, State, Array) -> State` | Receive the fitness for the initial population and update the algorithm's state.                           |
 
 ### Migrate from traditional EC library
 
@@ -167,6 +169,14 @@ class ExampleGA(Algorithm):
             fit=jnp.full((self.pop_size,), jnp.inf),
             key=key,
         )
+
+    def init_ask(self, state):
+        # initial the fitness for our initial population
+        return pop, state
+
+    def init_tell(self, state, fitness):
+        # update the fitness for the initial population
+        return state.update(fit=fitness)
 
     def ask(self, state):
         key, mut_key, x_key = random.split(state.key, 3)

--- a/src/evox/algorithms/mo/nsga2.py
+++ b/src/evox/algorithms/mo/nsga2.py
@@ -63,22 +63,17 @@ class NSGA2(Algorithm):
             population=population,
             fitness=jnp.zeros((self.pop_size, self.n_objs)),
             next_generation=population,
-            is_init=True,
             key=key,
         )
 
-    def ask(self, state):
-        return jax.lax.cond(state.is_init, self._ask_init, self._ask_normal, state)
-
-    def tell(self, state, fitness):
-        return jax.lax.cond(
-            state.is_init, self._tell_init, self._tell_normal, state, fitness
-        )
-
-    def _ask_init(self, state):
+    def init_ask(self, state):
         return state.population, state
 
-    def _ask_normal(self, state):
+    def init_tell(self, state, fitness):
+        state = state.update(fitness=fitness)
+        return state
+
+    def ask(self, state):
         key, sel_key1, x_key, mut_key = jax.random.split(state.key, 4)
         crossovered = self.selection(sel_key1, state.population, state.fitness)
         crossovered = self.crossover(x_key, state.population)
@@ -88,11 +83,7 @@ class NSGA2(Algorithm):
 
         return next_generation, state.update(next_generation=next_generation, key=key)
 
-    def _tell_init(self, state, fitness):
-        state = state.update(fitness=fitness, is_init=False)
-        return state
-
-    def _tell_normal(self, state, fitness):
+    def tell(self, state, fitness):
         merged_pop = jnp.concatenate([state.population, state.next_generation], axis=0)
         merged_fitness = jnp.concatenate([state.fitness, fitness], axis=0)
 

--- a/src/evox/algorithms/mo/nsga3.py
+++ b/src/evox/algorithms/mo/nsga3.py
@@ -78,18 +78,14 @@ class NSGA3(Algorithm):
             key=key,
         )
 
-    def ask(self, state):
-        return jax.lax.cond(state.is_init, self._ask_init, self._ask_normal, state)
-
-    def tell(self, state, fitness):
-        return jax.lax.cond(
-            state.is_init, self._tell_init, self._tell_normal, state, fitness
-        )
-
-    def _ask_init(self, state):
+    def init_ask(self, state):
         return state.population, state
 
-    def _ask_normal(self, state):
+    def init_tell(self, state, fitness):
+        state = state.update(fitness=fitness)
+        return state
+
+    def ask(self, state):
         key, sel_key1, mut_key, sel_key2, x_key = jax.random.split(state.key, 5)
         selected = self.selection(sel_key1, state.population)
         mutated = self.mutation(mut_key, selected)
@@ -101,11 +97,7 @@ class NSGA3(Algorithm):
         )
         return next_generation, state.update(next_generation=next_generation, key=key)
 
-    def _tell_init(self, state, fitness):
-        state = state.update(fitness=fitness, is_init=False)
-        return state
-
-    def _tell_normal(self, state, fitness):
+    def tell(self, state, fitness):
         merged_pop = jnp.concatenate([state.population, state.next_generation], axis=0)
         merged_fitness = jnp.concatenate([state.fitness, fitness], axis=0)
 

--- a/src/evox/algorithms/so/es_variants/__init__.py
+++ b/src/evox/algorithms/so/es_variants/__init__.py
@@ -19,9 +19,9 @@ try:
     # optional dependency: flax
     from .les import LES
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_error_msg = str(e)
 
     def LES(*args, **kwargs):
         raise ImportError(
-            f'LES requires flax but got "{original_erorr_msg}" when importing'
+            f'LES requires flax but got "{original_error_msg}" when importing'
         )

--- a/src/evox/algorithms/so/pso_variants/cso.py
+++ b/src/evox/algorithms/so/pso_variants/cso.py
@@ -43,6 +43,12 @@ class CSO(Algorithm):
             key=state_key,
         )
 
+    def init_ask(self, state):
+        return state.population, state
+
+    def init_tell(self, state, fitness):
+        return state.update(fitness=fitness)
+
     def ask(self, state):
         key, pairing_key, lambda1_key, lambda2_key, lambda3_key = jax.random.split(
             state.key, num=5

--- a/src/evox/core/algorithm.py
+++ b/src/evox/core/algorithm.py
@@ -8,9 +8,13 @@ from .state import State
 
 
 class Algorithm(Stateful):
-    """Base class for all algorithms
+    """Base class for all algorithms"""
 
-    """
+    def init_ask(self, state: State) -> Tuple[jax.Array, State]:
+        return None, State()
+
+    def init_tell(self, state: State) -> State:
+        return State()
 
     def ask(self, state: State) -> Tuple[jax.Array, State]:
         """Ask the algorithm

--- a/src/evox/core/algorithm.py
+++ b/src/evox/core/algorithm.py
@@ -11,9 +11,42 @@ class Algorithm(Stateful):
     """Base class for all algorithms"""
 
     def init_ask(self, state: State) -> Tuple[jax.Array, State]:
+        """Ask the algorithm for the initial population
+
+        Override this method if you need to initialize the population in a special way.
+        For example, Genetic Algorithm needs to evaluate the fitness of the initial population of size N,
+        but after that, it only need to evaluate the fitness of the offspring of size M, and N != M.
+        Since JAX requires the function return to have static shape, we need to have two different functions,
+        one is the normal `ask` and another is `init_ask`.
+
+        Parameters
+        ----------
+        state
+            The state of this algorithm.
+
+        Returns
+        -------
+        population
+            The candidate solution.
+        state
+            The new state of the algorithm.
+        """
         return None, State()
 
     def init_tell(self, state: State) -> State:
+        """Tell the algorithm the fitness of the initial population
+        Use in pair with `init_ask`.
+
+        Parameters
+        ----------
+        state
+            The state of this algorithm
+
+        Returns
+        -------
+        state
+            The new state of the algorithm
+        """
         return State()
 
     def ask(self, state: State) -> Tuple[jax.Array, State]:

--- a/src/evox/problems/neuroevolution/reinforcement_learning/__init__.py
+++ b/src/evox/problems/neuroevolution/reinforcement_learning/__init__.py
@@ -1,31 +1,31 @@
 try:
     from .brax import Brax
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_brax_error_msg = str(e)
 
     def Brax(*args, **kwargs):
         raise ImportError(
-            f'Brax requires brax but got "{original_erorr_msg}" when importing'
+            f'Brax requires brax but got "{original_brax_error_msg}" when importing'
         )
 
 try:
     # optional dependency: gym
     from .gym import Gym
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_gym_error_msg = str(e)
 
     def Gym(*args, **kwargs):
         raise ImportError(
-            f'Gym requires gym, ray but got "{original_erorr_msg}" when importing'
+            f'Gym requires gym, ray but got "{original_gym_error_msg}" when importing'
         )
-    
+
 try:
     # optional dependency: gym
     from .env_pool import EnvPool
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_envpool_error_msg = str(e)
 
     def EnvPool(*args, **kwargs):
         raise ImportError(
-            f'EnvPool requires env_pool but got "{original_erorr_msg}" when importing'
+            f'EnvPool requires env_pool but got "{original_envpool_error_msg}" when importing'
         )

--- a/src/evox/problems/neuroevolution/supervised_learning/__init__.py
+++ b/src/evox/problems/neuroevolution/supervised_learning/__init__.py
@@ -2,9 +2,9 @@ try:
     # optional dependency: torchvision, optax
     from .torchvision_dataset import TorchvisionDataset
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_error_msg = str(e)
 
     def TorchvisionDataset(*args, **kwargs):
         raise ImportError(
-            f'TorchvisionDataset requires torchvision, optax but got "{original_erorr_msg}" when importing'
+            f'TorchvisionDataset requires torchvision, optax but got "{original_error_msg}" when importing'
         )

--- a/src/evox/utils/common.py
+++ b/src/evox/utils/common.py
@@ -1,12 +1,18 @@
 from collections.abc import Iterable
 from functools import partial
-from typing import Union, List
+from typing import List, Union
 
-from jax import vmap, jit
+import jax
 import jax.numpy as jnp
+from jax import jit, vmap
 from jax.tree_util import tree_flatten, tree_leaves, tree_unflatten
 
 from ..core.module import *
+
+
+def algorithm_has_init_ask(algorithm, state):
+    probe = jax.eval_shape(algorithm.init_ask, state)
+    return probe[0] is not None
 
 
 def min_by(

--- a/src/evox/workflows/__init__.py
+++ b/src/evox/workflows/__init__.py
@@ -5,9 +5,9 @@ try:
     # optional dependency: ray
     from .distributed import RayDistributedWorkflow
 except ImportError as e:
-    original_erorr_msg = str(e)
+    original_error_msg = str(e)
 
-    def DistributedWorkflow(*args, **kwargs):
+    def RayDistributedWorkflow(*args, **kwargs):
         raise ImportError(
-            f'DistributedWorkflow requires ray, but got "{original_erorr_msg}" when importing'
+            f'RayDistributedWorkflow requires ray, but got "{original_error_msg}" when importing'
         )

--- a/tests/test_distributed_pipeline.py
+++ b/tests/test_distributed_pipeline.py
@@ -15,7 +15,6 @@ def test_distributed_cso():
             pop_size=20,
         ),
         problem=problems.numerical.Ackley(),
-        pop_size=10,
         num_workers=2,
         monitor=monitor,
         options={"num_cpus": 0.5, "num_gpus": 0},  # just for testing purpose

--- a/tests/test_uni_workflow.py
+++ b/tests/test_uni_workflow.py
@@ -56,6 +56,31 @@ def run_uni_workflow_with_non_jit_problem():
     return min_fitness
 
 
+def test_uni_workflow_sanity_check():
+    monitor = StdSOMonitor()
+    # create a workflow
+    workflow = workflows.UniWorkflow(
+        algorithm=algorithms.PSO(
+            lb=jnp.full(shape=(2,), fill_value=-1),
+            ub=jnp.full(shape=(2,), fill_value=1),
+            pop_size=20,
+        ),
+        problem=problems.numerical.Sphere(),
+        monitor=monitor,
+        jit_problem=True,
+    )
+
+    key = jax.random.PRNGKey(42)
+    state = workflow.init(key)
+
+    for i in range(10):
+        state = workflow.step(state)
+
+    monitor.close()
+    min_fitness = monitor.get_best_fitness()
+    assert min_fitness < 1e-2
+
+
 def test_uni_workflow():
     min_fitness2 = run_uni_workflow_with_non_jit_problem()
     min_fitness1 = run_uni_workflow_with_jit_problem()


### PR DESCRIPTION
## Description
<!--
Please describe your pull request here
-->

Add two new methods `init_ask` and `init_tell`, allowing the algorithm to easily initialize it's initial population.
Since JAX requires static shape, we expect `ask` always returns the same population size. However, this makes algorithm initialization quite tricky. This PR will help ease the problem.

## Checklist
<!--
A quick checklist, please check what applies to your pull request (put "x" in the brackets)
-->

- [x] I have formatted my Python code with `black`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [x] Added related test cases.
  - [x] Added docstring to explain important parameters.
  - [x] Added entries in the docs.
