### PR TITLE
fix the bug of state.key in immoea

### DIFF
--- a/src/evox/algorithms/mo/im_moea.py
+++ b/src/evox/algorithms/mo/im_moea.py
@@ -249,7 +249,7 @@ class IMMOEA(Algorithm):
             mask: n*1 bool array
             fitness: N*M matrix
         """
-        key, pop_key, x_key, mut_key = jax.random.split(state.key, 4)
+        new_key, key, pop_key, x_key, mut_key = jax.random.split(state.key, 5)
         n = jnp.sum(mask)
         N = population.shape[0]
         D = population.shape[1]
@@ -354,4 +354,4 @@ class IMMOEA(Algorithm):
             n >= 2 * self.n_objs, normal_fun, lambda x: population, x_key
         )
         final_pop = self.mutation(mut_key, final_pop)
-        return final_pop, state
+        return final_pop, state.update(key=new_key)


### PR DESCRIPTION
## Description
<!--
fix the bug of state.key in immoea, just two rows
-->

## Checklist
<!--
A quick checklist, please check what applies to your pull request (put "x" in the brackets)
-->

- [x] I have formatted my Python code with `black`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [x] Added related test cases.
  - [x] Added docstring to explain important parameters.
  - [x] Added entries in the docs.
