### PR TITLE
[Fix] Allow different `method` in non_dominated_sort after jitted

### DIFF
--- a/src/evox/operators/selection/non_dominate.py
+++ b/src/evox/operators/selection/non_dominate.py
@@ -27,7 +27,7 @@ def host_rank_from_domination_matrix(dominate_mat, dominate_count):
     return rank
 
 
-@jit
+@partial(jit, static_argnums=(1,))
 def non_dominated_sort(x, method="auto"):
     """Perform non-dominated sort
     Parameters


### PR DESCRIPTION
## Description
Currently, users cannot use other `method` options in `non_dominated_sort `, since it is not marked as static.

## Checklist

- [x] I have formatted my Python code with `black`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [ ] Added related test cases.
  - [ ] Added docstring to explain important parameters.
  - [ ] Added entries in the docs.
