### PR TITLE
Fixed an array out of bounds bug in SHADE when pop_size>100 

### DIFF
--- a/src/evox/algorithms/de_variants/sade.py
+++ b/src/evox/algorithms/de_variants/sade.py
@@ -137,8 +137,8 @@ class SaDE(Algorithm):
         current_vec = self.population[indices]
         vector_merge = torch.stack([rand_vec, best_vec, pbest_vec, current_vec])
 
-        base_vector_prim = torch.zeros(self.pop_size, 4, device=device)
-        base_vector_sec = torch.zeros(self.pop_size, 4, device=device)
+        base_vector_prim = torch.zeros(self.pop_size, self.dim, device=device)
+        base_vector_sec = torch.zeros(self.pop_size, self.dim, device=device)
 
         for i in range(4):
             base_vector_prim = torch.where(base_vec_prim_type.unsqueeze(1) == i, vector_merge[i], base_vector_prim)

--- a/src/evox/algorithms/de_variants/shade.py
+++ b/src/evox/algorithms/de_variants/shade.py
@@ -53,9 +53,9 @@ class SHADE(Algorithm):
         self.diff_padding_num = diff_padding_num
         # setup
         self.best_index = Mutable(torch.tensor(0, device=device))
-        self.Memory_FCR = Mutable(torch.full((2, 100), fill_value=0.5, device=device))
+        self.Memory_FCR = Mutable(torch.full((2, pop_size), fill_value=0.5, device=device))
         self.population = Mutable(torch.randn(pop_size, dim, device=device) * (ub - lb) + lb)
-        self.fitness = Mutable(torch.full((self.pop_size,), fill_value=torch.inf, device=device))
+        self.fitness = Mutable(torch.full((pop_size,), fill_value=torch.inf, device=device))
 
     def step(self):
         """


### PR DESCRIPTION
## Description
Fixed an array out of bounds bug in SHADE when pop_size>100 
<!--
Please describe your pull request here
-->

## Checklist
<!--
A quick checklist, please check what applies to your pull request (put "x" in the brackets)
-->

- [x] I have formatted my Python code with `ruff`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [x] Added related test cases.
  - [x] Added docstring to explain important parameters.
  - [x] Added entries in the docs.
