### PR TITLE
Change cec2022.py to avoid accuracy blowout in the extreme

### DIFF
--- a/src/evox/problems/numerical/cec2022.py
+++ b/src/evox/problems/numerical/cec2022.py
@@ -218,6 +218,7 @@ class CEC2022(Problem):
             )
             * 10000
             / 1e10 / 1e10 / 1e10,
+            # if divide by 1e30 , cause NVRTC compilation error(https://github.com/pytorch/pytorch/issues/62962)
             self.discus_func(self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 3 * nx : 4 * nx], self.M[:, 3 * nx : 4 * nx]))
             * 10000
             / 1e10,
@@ -311,6 +312,7 @@ class CEC2022(Problem):
             )
             * 10000
             / 1e10 / 1e10 / 1e10,
+            # if divide by 1e30 , cause NVRTC compilation error(https://github.com/pytorch/pytorch/issues/62962)
             self.ellips_func(self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 4 * nx : 5 * nx], self.M[:, 4 * nx : 5 * nx]))
             * 10000
             / 1e10,

--- a/src/evox/problems/numerical/cec2022.py
+++ b/src/evox/problems/numerical/cec2022.py
@@ -127,12 +127,12 @@ class CEC2022(Problem):
             diff = x - shift[:, i * nx : (i + 1) * nx]
             w = torch.sum(diff**2, dim=1)
             w = torch.where(w != 0, (1 / torch.sqrt(w)) * torch.exp(-w / (2 * nx * d * d)), torch.inf)
-            w_sum += w
+            w_sum = w_sum + w
             w_all.append(w * (f + b))
         w_ret = torch.zeros(x.size(0), device=x.device)
         w_sum = torch.where(w_sum == 0, 1e-9, w_sum)
         for w in w_all:
-            w_ret += w / w_sum
+            w_ret = w_ret + w / w_sum
         return w_ret
 
     # cSpell:words Zakharov Rosenbrock Schaffer Rastrigin hgbat katsuura ackley schwefel happycat grie_rosen ellips escaffer griewank
@@ -217,7 +217,7 @@ class CEC2022(Problem):
                 self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 2 * nx : 3 * nx], self.M[:, 2 * nx : 3 * nx])
             )
             * 10000
-            / 1e30,
+            / 1e10 / 1e10 / 1e10,
             self.discus_func(self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 3 * nx : 4 * nx], self.M[:, 3 * nx : 4 * nx]))
             * 10000
             / 1e10,
@@ -310,7 +310,7 @@ class CEC2022(Problem):
                 self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 3 * nx : 4 * nx], self.M[:, 3 * nx : 4 * nx])
             )
             * 10000
-            / 1e30,
+            / 1e10 / 1e10 / 1e10,
             self.ellips_func(self.sr_func_rate(x, 1.0, True, True, self.OShift[:, 4 * nx : 5 * nx], self.M[:, 4 * nx : 5 * nx]))
             * 10000
             / 1e10,


### PR DESCRIPTION
## Description
Change cec2022.py to avoid accuracy blowout in the extreme

## Checklist
<!--
A quick checklist, please check what applies to your pull request (put "x" in the brackets)
-->

- [x] I have formatted my Python code with `ruff`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [ ] Added related test cases.
  - [ ] Added docstring to explain important parameters.
  - [ ] Added entries in the docs.
