### PR TITLE
BatchedTensor fixes

### DIFF
--- a/src/evox/problems/neuroevolution/brax.py
+++ b/src/evox/problems/neuroevolution/brax.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 import torch.utils.dlpack
 from brax import envs
 from brax.io import html, image
+from torch._C._functorch import get_unwrapped, is_batchedtensor
 
 from evox.core import Problem, use_state
 from evox.utils import VmapInfo
@@ -22,6 +23,8 @@ from .utils import get_vmap_model_state_forward
 # because they have a __dlpack__ method, which is called by their respective from_dlpack methods.
 def to_jax_array(x: torch.Tensor) -> jax.Array:
     # When the torch has GPU support but the jax does not, we need to move the tensor to CPU first.
+    if is_batchedtensor(x):
+        x = get_unwrapped(x)
     if x.device.type != "cpu" and jax.default_backend() == "cpu":
         return jax.dlpack.from_dlpack(x.detach().cpu())
     return jax.dlpack.from_dlpack(x.detach())

--- a/src/evox/workflows/eval_monitor.py
+++ b/src/evox/workflows/eval_monitor.py
@@ -106,8 +106,8 @@ class EvalMonitor(Monitor):
                 topk_solutions = torch.concatenate([self.topk_solutions, self.latest_solution])
                 topk_fitness = torch.concatenate([self.topk_fitness, fitness])
                 rank = torch.topk(topk_fitness, self.topk, largest=False)[1]
-                self.topk_fitness.copy_(topk_fitness[rank])
-                self.topk_solutions.copy_(topk_solutions[rank])
+                self.topk_fitness = topk_fitness[rank]
+                self.topk_solutions = topk_solutions[rank]
         elif fitness.ndim == 2:
             # multi-objective
             self.multi_obj = True


### PR DESCRIPTION
## Description
<!--
Please describe your pull request here
-->
Manually use `torch._C._functorch.get_unwrapped` to unwrap the `BatchedTensor` to normal `Tensor` when necessary.
This pr fixes two issues:
- EvalMonitor's history may contain `BatchedTensor`.
- Dlpack doesn't work in vmap. Hopefully closes https://github.com/EMI-Group/evox/issues/220.

## Checklist
<!--
A quick checklist, please check what applies to your pull request (put "x" in the brackets)
-->

- [x] I have formatted my Python code with `ruff`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [ ] Added related test cases.
  - [ ] Added docstring to explain important parameters.
  - [ ] Added entries in the docs.
