### PR TITLE
Some vmap and HPO related features and bug fixes

### DIFF
--- a/src/evox/problems/hpo_wrapper.py
+++ b/src/evox/problems/hpo_wrapper.py
@@ -1,18 +1,48 @@
-import copy
+import weakref
 from abc import ABC
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 from torch import nn
 
-from evox.core import Monitor, Mutable, Problem, Workflow, use_state, vmap
+from evox.core import Monitor, Mutable, Problem, Workflow, compile, use_state, vmap
+
+
+def _vmap_vmap_mean_fit_aggregation(info, in_dims, fit: torch.Tensor) -> Tuple[torch.Tensor, int]:
+    return torch.mean(fit.movedim(in_dims[0], 0), dim=0, keepdim=True), 0
+
+
+@torch.library.custom_op("evox::_hpo_vmap_mean_fit_aggregation", mutates_args=())
+def _vmap_mean_fit_aggregation(fit: torch.Tensor) -> torch.Tensor:
+    return fit.clone()
+
+
+_vmap_mean_fit_aggregation.register_fake(lambda f: f.new_empty(f.size()))
+_vmap_mean_fit_aggregation.register_vmap(_vmap_vmap_mean_fit_aggregation)
+
+
+@torch.library.custom_op("evox::_hpo_mean_fit_aggregation", mutates_args=())
+def _mean_fit_aggregation(fit: torch.Tensor) -> torch.Tensor:
+    return fit.clone()
+
+
+_mean_fit_aggregation.register_fake(lambda f: f.new_empty(f.size()))
+_mean_fit_aggregation.register_vmap(
+    lambda info, in_dims, fit: (_vmap_mean_fit_aggregation(fit.movedim(in_dims[0], 0)), 0)
+)
 
 
 class HPOMonitor(Monitor, ABC):
     """The base class for hyper parameter optimization (HPO) monitors used in `HPOProblem.workflow.monitor`."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        num_repeats: int = 1,
+        fit_aggregation: Optional[Callable[[torch.Tensor, int], torch.Tensor]] = _mean_fit_aggregation,
+    ):
         super().__init__()
+        self.num_repeats = num_repeats
+        self.fit_aggregation = fit_aggregation
 
     def tell_fitness(self) -> torch.Tensor:
         """Get the best fitness found so far in the optimization process that this monitor is monitoring.
@@ -25,14 +55,19 @@ class HPOMonitor(Monitor, ABC):
 class HPOFitnessMonitor(HPOMonitor):
     """The monitor for hyper parameter optimization (HPO) that records the best fitness found so far in the optimization process."""
 
-    def __init__(self, multi_obj_metric: Optional[Callable] = None):
+    def __init__(
+        self,
+        num_repeats: int = 1,
+        fit_aggregation: Optional[Callable[[torch.Tensor, int], torch.Tensor]] = _mean_fit_aggregation,
+        multi_obj_metric: Optional[Callable] = None,
+    ):
         """
         Initialize the HPO fitness monitor.
 
         :param multi_obj_metric: The metric function to use for multi-objective optimization, unused in single-objective optimization.
             Currently we only support "IGD" or "HV" for multi-objective optimization. Defaults to `None`.
         """
-        super().__init__()
+        super().__init__(num_repeats, fit_aggregation)
         assert multi_obj_metric is None or callable(multi_obj_metric), (
             f"Expect `multi_obj_metric` to be `None` or callable, got {multi_obj_metric}"
         )
@@ -46,7 +81,7 @@ class HPOFitnessMonitor(HPOMonitor):
 
         :raises AssertionError: If the dimensionality of the fitness tensor is not 1 or 2.
         """
-        assert 1 <= fitness.ndim <= 2
+        fitness = self.fit_aggregation(fitness) if self.num_repeats > 1 else fitness
         if fitness.ndim == 1:
             # single-objective
             self.best_fitness = torch.min(torch.min(fitness), self.best_fitness)
@@ -74,28 +109,73 @@ def get_sub_state(state: Dict[str, Any], name: str):
     return state
 
 
+__hpo_data__: Dict[
+    int,
+    Tuple[
+        Callable[[Dict[str, torch.Tensor]], Tuple[Dict[str, torch.Tensor]]],  # workflow_step
+        List[str],  # state_keys or param_keys
+        Optional[List[str]],  # optional buffer_keys
+    ],
+] = {}
+
+
+def _fake_hpo_evaluate_loop(id: int, iterations: int, state_values: List[torch.Tensor]) -> List[torch.Tensor]:
+    return [v.new_empty(v.size()) for v in state_values]
+
+
+@torch.library.custom_op("evox::_hpo_evaluate_loop", mutates_args=())
+def _hpo_evaluate_loop(id: int, iterations: int, state_values: List[torch.Tensor]) -> List[torch.Tensor]:
+    global __hpo_data__
+    workflow_step, *state_keys = __hpo_data__[id]
+    if len(state_keys) == 1:
+        state_keys = state_keys[0]
+        state = {k: v.clone() for k, v in zip(state_keys, state_values)}
+        for _ in range(iterations):
+            state = workflow_step(state)
+        return [state[k] for k in state_keys]
+    else:
+        param_keys, buffer_keys = state_keys[0], state_keys[1]
+        params = {k: v.clone() for k, v in zip(param_keys, state_values)}
+        buffers = {k: v.clone() for k, v in zip(buffer_keys, state_values[len(param_keys) :])}
+        for _ in range(iterations):
+            params, buffers = workflow_step(params, buffers)
+        return [params[k] for k in param_keys] + [buffers[k] for k in buffer_keys]
+
+
+_hpo_evaluate_loop.register_fake(_fake_hpo_evaluate_loop)
+
+
 class HPOProblemWrapper(Problem):
     """The problem for hyper parameter optimization (HPO).
 
-    ## Usage
-    ```
+    ## Example
+    ```python
     algo = SomeAlgorithm(...)
     prob = SomeProblem(...)
     monitor = HPOFitnessMonitor()
     workflow = StdWorkflow(algo, prob, monitor=monitor)
     hpo_prob = HPOProblemWrapper(iterations=..., num_instances=...)
-    params = HPOProblemWrapper.extract_parameters(hpo_prob.init_state)
+    params = hpo_prob.get_init_params()
+    # alter `params` ...
     hpo_prob.evaluate(params) # execute the evaluation
     # ...
     ```
     """
 
-    def __init__(self, iterations: int, num_instances: int, workflow: Workflow, copy_init_state: bool = True):
+    def __init__(
+        self,
+        iterations: int,
+        num_instances: int,
+        workflow: Workflow,
+        num_repeats: int = 1,
+        copy_init_state: bool = False,
+    ):
         """Initialize the HPO problem wrapper.
 
         :param iterations: The number of iterations to be executed in the optimization process.
-        :param num_instances: The number of instances to be executed in parallel in the optimization process.
+        :param num_instances: The number of instances to be executed in parallel in the optimization process, i.e., the population size of the outer algorithm.
         :param workflow: The workflow to be used in the optimization process. Must be wrapped by `core.jit_class`.
+        :param num_repeats: The number of times to repeat the evaluation process for each instance. Defaults to 1.
         :param copy_init_state: Whether to copy the initial state of the workflow for each evaluation. Defaults to `True`. If your workflow contains operations that IN-PLACE modify the tensor(s) in initial state, this should be set to `True`. Otherwise, you can set it to `False` to save memory.
         """
         super().__init__()
@@ -103,26 +183,96 @@ class HPOProblemWrapper(Problem):
         assert num_instances > 0, f"`num_instances` should be greater than 0, got {num_instances}"
         self.iterations = iterations
         self.num_instances = num_instances
+        self.num_repeats = num_repeats
         self.copy_init_state = copy_init_state
         # check monitor
         monitor = workflow.monitor
         assert isinstance(monitor, HPOMonitor), f"Expect workflow monitor to be `HPOMonitor`, got {type(monitor)}"
-        self.hpo_monitor = monitor
+        monitor.num_repeats = num_repeats
+
+        # compile workflow steps
         state_step = use_state(workflow.step)
 
-        # JIT workflow step
-        vmap_state_step = vmap(state_step, randomness="same")
+        def repeat_state_step(params: Dict[str, torch.Tensor], buffers: Dict[str, torch.Tensor]):
+            state = {**params, **buffers}
+            state = state_step(state)
+            return {k: state[k] for k in params.keys()}, {k: state[k] for k in buffers.keys()}
+
+        vmap_state_step = (
+            torch.vmap(
+                torch.vmap(repeat_state_step, randomness="same"),
+                randomness="different",
+                in_dims=(None, 0),
+                out_dims=(None, 0),
+            )
+            if num_repeats > 1
+            else torch.vmap(state_step, randomness="same")
+        )
         self._init_params, self._init_buffers = torch.func.stack_module_state([workflow] * self.num_instances)
-        self._workflow_step_ = torch.compile(vmap_state_step)
+        if num_repeats > 1:
+            self._init_buffers = {k: torch.stack([v] * num_repeats) for k, v in self._init_buffers.items()}
+        self._workflow_step_ = compile(vmap_state_step, fullgraph=True)
+
         if type(workflow).init_step == Workflow.init_step:
             # if no init step
-            print("No init step")
             self._workflow_init_step_ = self._workflow_step_
         else:
-            # otherwise, JIT workflow init step
+            # otherwise, compile workflow init step
             state_init_step = use_state(workflow.init_step)
-            vmap_state_init_step = vmap(state_init_step, randomness="same")
-            self._workflow_init_step_ = torch.compile(vmap_state_init_step)
+
+            def repeat_state_init_step(params: Dict[str, torch.Tensor], buffers: Dict[str, torch.Tensor]):
+                state = {**params, **buffers}
+                state = state_step(state)
+                return {k: state[k] for k in params.keys()}, {k: state[k] for k in buffers.keys()}
+
+            vmap_state_init_step = (
+                torch.vmap(
+                    torch.vmap(repeat_state_init_step, randomness="same"),
+                    randomness="different",
+                    in_dims=(None, 0),
+                    out_dims=(None, 0),
+                )
+                if num_repeats > 1
+                else torch.vmap(state_init_step, randomness="same")
+            )
+            self._workflow_init_step_ = compile(vmap_state_init_step, fullgraph=True)
+
+        # TODO: is final step necessary?
+        # if type(workflow).final_step == Workflow.final_step:
+        #     # if no final step
+        #     self._workflow_final_step_ = self._workflow_step_
+        # else:
+        #     # otherwise, compile workflow final step
+        #     state_final_step = use_state(workflow.final_step)
+
+        #     def repeat_state_final_step(params: Dict[str, torch.Tensor], buffers: Dict[str, torch.Tensor]):
+        #         state = {**params, **buffers}
+        #         state = state_step(state)
+        #         return {k: state[k] for k in params.keys()}, {k: state[k] for k in buffers.keys()}
+
+        #     vmap_state_final_step = (
+        #         torch.vmap(
+        #             torch.vmap(repeat_state_final_step, randomness="same"),
+        #             randomness="different",
+        #             in_dims=(None, 0),
+        #             out_dims=(None, 0),
+        #         )
+        #         if num_repeats > 1
+        #         else torch.vmap(state_final_step, randomness="same")
+        #     )
+        #     self._workflow_final_step_ = compile(vmap_state_final_step, fullgraph=True)
+
+        self.state_keys = (list(self._init_params.keys()), list(self._init_buffers.keys()))
+        if self.num_repeats == 1:
+            self.state_keys = sum(self.state_keys, [])
+        global __hpo_data__
+        __hpo_data__[id(self)] = (self._workflow_step_,) + (
+            (self.state_keys,) if self.num_repeats == 1 else self.state_keys
+        )
+        self._id_ = id(self)
+        weakref.finalize(self, __hpo_data__.pop, id(self), None)
+
+        self._stateful_tell_fitness = use_state(monitor.tell_fitness)
 
     def evaluate(self, hyper_parameters: Dict[str, nn.Parameter]):
         """
@@ -133,25 +283,48 @@ class HPOProblemWrapper(Problem):
         :return: The final fitness of the hyper parameters.
         """
         # hyper parameters check
-        for k, _v in hyper_parameters.items():
+        for k, _ in hyper_parameters.items():
             assert k in self._init_params, (
                 f"`{k}` should be a hyperparameter of the workflow, available keys are {self.get_params_keys()}"
             )
 
-        state = self._init_params | self._init_buffers
-        if self.copy_init_state:
-            state = copy.deepcopy(state)
-
-        # Override with the given hyper parameters
-        state.update(hyper_parameters)
-        # run the workflow
-        state = self._workflow_init_step_(state)
-        for _ in range(self.iterations - 1):
-            state = self._workflow_step_(state)
-        # get final fitness
-        monitor_state = get_sub_state(state, "monitor")
-        _monitor_state, fit = vmap(use_state(self.hpo_monitor.tell_fitness), randomness="same")(monitor_state)
-        return fit
+        if self.num_repeats > 1:
+            if self.copy_init_state:
+                params = {k: v.clone() for k, v in self._init_params.items()}
+                buffers = {k: v.clone() for k, v in self._init_buffers.items()}
+            else:
+                params = self._init_params
+                buffers = self._init_buffers
+            params = {**self._init_params, **hyper_parameters}
+            # run the workflow
+            params, buffers = self._workflow_init_step_(params, buffers)
+            state_values = [params[k] for k in self.state_keys[0]] + [buffers[k] for k in self.state_keys[1]]
+            state_values = _hpo_evaluate_loop(self._id_, self.iterations - 2, state_values)
+            params = {k: v for k, v in zip(self.state_keys[0], state_values)}
+            buffers = {k: v for k, v in zip(self.state_keys[1], state_values[len(params) :])}
+            # TODO: is final step necessary?
+            # params, buffers = self._workflow_final_step_(params, buffers)
+            # get final fitness
+            monitor_state = get_sub_state(buffers, "monitor")
+            _, fit = vmap(torch.vmap(self._stateful_tell_fitness))(monitor_state)
+            return fit[0]
+        else:
+            state: Dict[str, torch.Tensor] = {**self._init_params, **self._init_buffers}
+            if self.copy_init_state:
+                state = {k: v.clone() for k, v in state.items()}
+            # Override with the given hyper parameters
+            state.update(hyper_parameters)
+            # run the workflow
+            state = self._workflow_init_step_(state)
+            state_values = [state[k] for k in self.state_keys]
+            state_values = _hpo_evaluate_loop(self._id_, self.iterations - 2, state_values)
+            state = {k: v for k, v in zip(self.state_keys, state_values)}
+            # TODO: is final step necessary?
+            # state = self._workflow_final_step_(state)
+            # get final fitness
+            monitor_state = get_sub_state(state, "monitor")
+            _, fit = vmap(self._stateful_tell_fitness)(monitor_state)
+            return fit
 
     def get_init_params(self):
         """Return the initial hyper-parameters dictionary of the underlying workflow."""

--- a/src/evox/problems/neuroevolution/brax.py
+++ b/src/evox/problems/neuroevolution/brax.py
@@ -243,6 +243,7 @@ class BraxProblem(Problem):
         ## Warning
         This problem does NOT support HPO wrapper (`problems.hpo_wrapper.HPOProblemWrapper`) out-of-box, i.e., the workflow containing this problem CANNOT be vmapped.
         *However*, by setting `pop_size` to the multiplication of inner population size and outer population size, you can still use this problem in a HPO workflow.
+        Yet, the `num_repeats` of HPO wrapper *must* be set to 1, please use the parameter `num_episodes` instead.
 
         ## Examples
         >>> from evox import problems

--- a/src/evox/problems/neuroevolution/brax.py
+++ b/src/evox/problems/neuroevolution/brax.py
@@ -197,7 +197,7 @@ def _fake_evaluate_brax_vmap(
     return (
         key.new_empty(key.size()),
         [v.new_empty(v.size()).movedim(d, 0) for d, v in zip(in_dim, model_state)],
-        model_state[0].new_empty(batch_size, pop_size, num_episodes),
+        model_state[0].new_empty(batch_size, pop_size // batch_size, num_episodes),
     )
 
 

--- a/unit_test/operators/test_non_dominate.py
+++ b/unit_test/operators/test_non_dominate.py
@@ -1,0 +1,26 @@
+import unittest
+
+import torch
+
+from evox.core import compile, vmap
+from evox.operators.selection import non_dominate_rank
+
+
+class TestNonDominate(unittest.TestCase):
+    def setUp(self):
+        torch.set_default_device("cuda")
+        self.n, self.m = 12, 3
+        self.f = torch.randn(self.n, self.m)
+        self.rank = non_dominate_rank(self.f)
+
+    def test_compile(self):
+        rank = compile(non_dominate_rank)(self.f)
+        self.assertTrue(torch.equal(rank, self.rank))
+
+    def test_vmap(self):
+        rank = compile(vmap(non_dominate_rank))(torch.stack([self.f] * 5))
+        self.assertTrue(torch.equal(rank, torch.stack([self.rank] * 5)))
+
+    def test_vmap_vmap(self):
+        rank = compile(vmap(vmap(non_dominate_rank)))(torch.stack([torch.stack([self.f] * 5)] * 3))
+        self.assertTrue(torch.equal(rank, torch.stack([torch.stack([self.rank] * 5)] * 3)))

--- a/unit_test/operators/test_non_dominate.py
+++ b/unit_test/operators/test_non_dominate.py
@@ -8,7 +8,7 @@ from evox.operators.selection import non_dominate_rank
 
 class TestNonDominate(unittest.TestCase):
     def setUp(self):
-        torch.set_default_device("cuda")
+        torch.set_default_device("cuda" if torch.cuda.is_available() else "cpu")
         self.n, self.m = 12, 3
         self.f = torch.randn(self.n, self.m)
         self.rank = non_dominate_rank(self.f)

--- a/unit_test/problems/test_brax.py
+++ b/unit_test/problems/test_brax.py
@@ -4,8 +4,9 @@ import unittest
 import torch
 import torch.nn as nn
 
-from evox.algorithms import PSO
+from evox.algorithms import DE, PSO
 from evox.core import compile
+from evox.problems.hpo_wrapper import HPOFitnessMonitor, HPOProblemWrapper
 from evox.problems.neuroevolution.brax import BraxProblem
 from evox.utils import ParamsAndVector
 from evox.workflows import EvalMonitor, StdWorkflow
@@ -169,3 +170,55 @@ class TestBraxProblem(unittest.TestCase):
         print(f"\tBest params: {best_params}")
 
         problem.visualize(best_params)
+
+    def test_hpo_brax_problem(self):
+        model = SimpleCNN()
+        for p in model.parameters():
+            p.requires_grad = False
+        total_params = sum(p.numel() for p in model.parameters())
+        print(f"Total number of model parameters: {total_params}")
+        print()
+
+        adapter = ParamsAndVector(dummy_model=model)
+        model_params = dict(model.named_parameters())
+        pop_center = adapter.to_vector(model_params)
+        lower_bound = pop_center - 1
+        upper_bound = pop_center + 1
+
+        POP_SIZE = 17
+        OUTER_POP = 7
+        problem = BraxProblem(
+            policy=model,
+            env_name="hopper",
+            max_episode_length=10,
+            num_episodes=3,
+            pop_size=POP_SIZE * OUTER_POP,
+        )
+
+        algorithm = PSO(
+            pop_size=POP_SIZE,
+            lb=lower_bound,
+            ub=upper_bound,
+        )
+
+        pop_monitor = HPOFitnessMonitor()
+
+        workflow = StdWorkflow(
+            algorithm=algorithm,
+            problem=problem,
+            monitor=pop_monitor,
+            opt_direction="max",
+            solution_transform=adapter,
+        )
+
+        outer_prob = HPOProblemWrapper(10, num_instances=OUTER_POP, workflow=workflow, copy_init_state=False)
+        outer_algo = DE(OUTER_POP, lb=torch.zeros(3), ub=torch.tensor([1.0, 5.0, 2.0], device=torch.get_default_device()))
+        outer_workflow = StdWorkflow(outer_algo, outer_prob, solution_transform=lambda x: {"algorithm.w": x[:, 0], "algorithm.phi_p": x[:, 1], "algorithm.phi_g": x[:, 2]})
+        compiled_step = compile(outer_workflow.step)
+        compiled_step()
+
+        for index in range(3):
+            print(f"In generation {index}:")
+            t = time.time()
+            compiled_step()
+        print(f"\tTime elapsed: {time.time() - t: .4f}(s).")


### PR DESCRIPTION
## Description
1. Fix a bug in `BraxProblem` that causes vmapped `BraxProblem` produces wrong graph in compilation.
2. Add `num_repeats` support in HPO to effectively use vmap to repeat the evaluation process for each instance.
3. Add `max_vmap_level` support in `register_vmap_op` to automatically register more levels of vmapped operator.
4. Set the maximum vmap support level of `non_dominate_rank` to 2 to support the `num_repeats` in HPO.
5. Add test cases for HPO `num_repeats` and Brax with HPO.

## To Discuss
- [ ] Please check whether a `final_step` method should be added to the algorithm and workflow since some of the evolutionary algorithms have special treatment at their last steps.

## Checklist
- [x] I have formatted my Python code with `ruff`.
- [x] I have good commit messages.
- If adding new algorithms, problems, operators:
  - [x] Added related test cases.
  - [x] Added docstring to explain important parameters.
  - [ ] Added entries in the docs.
