### PR TITLE
fix: restore the star history chart in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,5 +359,5 @@ EvoX is licensed under the **GNU General Public License v3.0 (GPL-3.0)**. For fu
 
 <!--
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=EMI-Group/evox&type=Date)](https://star-history.com/#EMI-Group/evox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EMI-Group/evox&type=Date)](https://star-history.dera.page/#EMI-Group/evox&Date)
 -->

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -364,5 +364,5 @@ EvoX 遵循 **GNU 通用公共许可证 3.0 (GPL-3.0)** 进行授权。完整的
 
 <!--
 ## Star 历史
-[![Star 历史图表](https://api.star-history.com/svg?repos=EMI-Group/evox&type=Date)](https://star-history.com/#EMI-Group/evox&Date)
+[![Star 历史图表](https://star-history.dera.page/svg?repos=EMI-Group/evox&type=Date)](https://star-history.dera.page/#EMI-Group/evox&Date)
 -->


### PR DESCRIPTION
The star history chart in README.md and README_ZH.md is broken and needs fixing. GitHub stargazer API restrictions have made the current chart endpoint unreliable, so we switch it to star-history.dera.page, which renders the same chart without requiring any token. The chart link now works at https://star-history.dera.page/#EMI-Group/evox&Date.